### PR TITLE
add `allowMissing` param to resource object definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,7 @@ Each resource object defines:
 - `name`: Name of the branch for this resource. This is the value used when using the `index` API below.
 - `version`: Semver value of this version. If omitted name will be used to determine the default index file.
 - `path`: Path to the directory containing this branch's source.
+- `allowMissing`: Optional parameter which allows for missing resources to be ignored, rather than throw an error
 
 Within the resource directory, the `index.html` and `module-map.json` files are given special treatment. All other files must not have duplicates and should be versioned via a system such as [lumbar-long-expires][].
 

--- a/lib/api/resource-loader.js
+++ b/lib/api/resource-loader.js
@@ -160,8 +160,9 @@ function generateAppCache(resources, app) {
   resources.forEach(function(instance) {
     var absolutePath = path.resolve(instance.path),
         instanceName = instance.name;
+        allowMissing = instance.allowMissing;
 
-    filelist(absolutePath).forEach(function(file) {
+    filelist(absolutePath, allowMissing).forEach(function(file) {
       var path = file.substring(absolutePath.length + 1);
       if (path === 'module-map.json') {
         return;
@@ -192,12 +193,15 @@ function generateAppCache(resources, app) {
   clientRoutes = _.uniq(clientRoutes).sort();
 }
 
-function filelist(path) {
+function filelist(path, allowMissing) {
   function readdir(path) {
     try {
       return fs.readdirSync(path).map(function(child) { return path + '/' + child; });
     } catch (err) {
-      if (err.code === 'ENOTDIR') {
+      var ENOTDIR = err.code === 'ENOTDIR',
+          ENOENT = err.code === 'ENOENT';
+
+      if (ENOTDIR || (ENOENT && allowMissing)) {
         return;
       } else {
         throw err;

--- a/test/api/resource-loader.js
+++ b/test/api/resource-loader.js
@@ -53,6 +53,26 @@ describe('resource-loader', function() {
         resourceLoader.register('appName!', []);
       }).to.throw('No resources defined');
     });
+    it('should ignore missing resources when requested', function() {
+      expect(function() {
+        resourceLoader.register('appName!', [
+          {name: 'foo', version: '1.0.0', path: 'bazbaz'},
+          {name: 'bar', version: '2.0.0', path: 'foo', allowMissing: true}
+        ]);
+
+        var info = [
+          {
+            name: 'appName!',
+            versions: [{
+              info: 'custom blerg: ' + process.cwd() + '/bazbaz/VERSION',
+              name: 'foo'
+            }]
+          }
+        ];
+
+        expect(resourceLoader.info()).to.eql(info);
+      });
+    });
   });
 
   describe('#info', function() {


### PR DESCRIPTION
In a normal localDev -> QA -> Prod flow, it is quite possible that
someone would want to have a resource being developed locally, and in
QA, but not ever be released to Prod (An in progress, major version,
backwards incompatible version for example). During that time period,
the QA server might need to be used to QA the stable version of the
resource.

This results in a setup like this

```
{
"resource" : [
    {
      "name": "a-stable",
      "version": "1.0.0",
      "path": "./stable"
    },
    {
      "name": "a-nextgen",
      "version": "2.0.0",
      "path": "./nextgen"
    }
  ]
}
```

This allows you to use both resources during local development and QA,
when it has been deployed properly. But if you are QAing an exact Prod
release, Hula-Hoop will current throw an error unless you include the
in progress (and most likely broken/incomplete) version. Rather than do
that, `allowMissing changes the above to

```
{
"resource" : [
    {
      "name": "a-stable",
      "version": "1.0.0",
      "path": "./stable"
    },
    {
      "name": "a-nextgen",
      "version": "2.0.0",
      "path": "./nextgen",
      "allowMissing": true
    }
  ]
}
```

Now, when Prod is being tested in QA, `resources` becomes

```
{
"resource" : [
    {
      "name": "a-stable",
      "version": "1.0.0",
      "path": "./stable"
    }
  ]
}
```

after resolution, and continues on its merry way.
