### PR TITLE
allow for index files to be resolved from the indexCache

### DIFF
--- a/lib/api/resource-loader.js
+++ b/lib/api/resource-loader.js
@@ -90,28 +90,38 @@ exports.info = function() {
   });
 };
 
-exports.asset = function(path) {
+exports.asset = function(path, app, branch) {
   if (!path) {
     return;
   }
 
   path = path.replace(/\/\//g, '/');
 
-  var container = exports.assetContainer(path);
+  var container = exports.assetContainer(path, app, branch);
   if (container) {
     return container + '/' + path;
   }
 };
-exports.assetContainer = function(path) {
-  if (!path) {
+exports.assetContainer = function(assetPath, app, branch) {
+  if (!assetPath) {
     return;
   }
 
   if (!pathCache) {
     generateCache();
   }
-  path = path.replace(/\/\//g, '/');
-  return pathCache[path];
+
+  assetPath = assetPath.replace(/\/\//g, '/');
+  if (/(^|\/)index\.html$/.test(assetPath)) {
+    // If assetContainer is called without `app` and `branch`,
+    // we can't use the indexCache, since it requires them
+    var checkIndex = app && branch;
+    if (checkIndex) {
+      var index = exports.index(app, branch);
+      return path.dirname(index);
+    }
+  }
+  return pathCache[assetPath];
 };
 exports.index = function(app, branch) {
   if (!app) {

--- a/lib/endpoints/resources.js
+++ b/lib/endpoints/resources.js
@@ -1,9 +1,9 @@
 var api = require('../api'),
     Hapi = require('hapi');
 
-exports.index = function() {
+exports.index = function(app, branch) {
   return function(req, reply) {
-    var path = api.resourceLoader.asset(req.params.platform + '/index.html');
+    var path = api.resourceLoader.asset(req.params.platform + '/index.html', app, branch);
     if (!path) {
       reply(Hapi.error.notFound());
     } else {


### PR DESCRIPTION
pathCache creates one entry per `index.html` file, so the `index.html` files with the same path (e.g. as a result of multiple branches being served simultaneously) that are registered afterwards are disregarded, and saved in indexCache.

The issue is we are never looking anything up in indexCache when it is requested. It was impossible before this because there was no way to look up the required `app` and `branch` vars.

This PR adds that ability. As a result `HulaHoop.endpoints.index` can be called with two optional parameters to get the correct index file.

written by @jhudson8 and @patrickkettner
